### PR TITLE
Add TS enhancements: interface skip, abstract, #private, param filter

### DIFF
--- a/lizard_languages/tsx.py
+++ b/lizard_languages/tsx.py
@@ -24,6 +24,7 @@ class TSXReader(TypeScriptReader):
         addition = addition + \
             r"|(?:<[A-Za-z][A-Za-z0-9]*(?:\.[A-Za-z][A-Za-z0-9]*)*>)" + \
             r"|(?:<\/[A-Za-z][A-Za-z0-9]*(?:\.[A-Za-z][A-Za-z0-9]*)*>)" + \
+            r"|(?:#\w+)" + \
             r"|(?:\$\w+)" + \
             r"|(?:<\/\w+>)" + \
             r"|(?:=>)" + \

--- a/lizard_languages/typescript.py
+++ b/lizard_languages/typescript.py
@@ -107,8 +107,8 @@ class TypeScriptReader(CodeReader, CCppCommentsMixin):
             # Always yield closing quote
             yield quote
 
-        # Restore original addition pattern for template literals
-        addition = addition + r"|(?:\$\w+)" + r"|(?:\w+\?)" + r"|`.*?`"
+        # Private method (#), dollar ($), optional chaining (?), template literals
+        addition = addition + r"|(?:#\w+)" + r"|(?:\$\w+)" + r"|(?:\w+\?)" + r"|`.*?`"
         for token in CodeReader.generate_tokens(source_code, addition, token_class):
             if (
                 isinstance(token, str)
@@ -120,6 +120,19 @@ class TypeScriptReader(CodeReader, CCppCommentsMixin):
                     yield t
                 continue
             yield token
+
+
+# TypeScript type keywords that should not be counted as parameters
+_TS_TYPE_KEYWORDS = frozenset([
+    'string', 'number', 'boolean', 'void', 'any',
+    'object', 'unknown', 'never',
+])
+
+# Built-in constructors/functions that should not be detected as function definitions.
+# These appear as `String(x)`, `Number(x)` etc. — calls, not definitions.
+_JS_BUILTIN_CALLABLES = frozenset([
+    'String', 'Number', 'Boolean', 'Array', 'Object',
+])
 
 
 class TypeScriptStates(CodeStateMachine):
@@ -136,6 +149,7 @@ class TypeScriptStates(CodeStateMachine):
         self._async_seen = False  # Track if 'async' was seen
         self._prev_token = ''  # Track previous token to detect method calls
         self._in_prop_value = False  # Track if inside property value (after ':')
+        self._in_abstract_context = False  # Track abstract method declarations
 
     def statemachine_before_return(self):
         # Ensure the main function is closed at the end
@@ -214,6 +228,31 @@ class TypeScriptStates(CodeStateMachine):
             self.next(handle_type_alias)
             return
 
+        # Skip interface declarations — method signatures are not runtime functions
+        if token == 'interface':
+            brace_count = 0
+            interface_started = False
+
+            def skip_interface(t):
+                nonlocal brace_count, interface_started
+                if t == '{':
+                    interface_started = True
+                    brace_count += 1
+                elif t == '}' and interface_started:
+                    brace_count -= 1
+                    if brace_count == 0:
+                        self.next(self._state_global)
+                        return True
+                return False
+
+            self.next(skip_interface)
+            return
+
+        # Track abstract modifier inside class bodies
+        if token == 'abstract' and self.as_object:
+            self._in_abstract_context = True
+            return
+
         # Track static and async modifiers
         if token == 'static':
             self._static_seen = True
@@ -244,7 +283,7 @@ class TypeScriptStates(CodeStateMachine):
             if token == ':':
                 # Only set function_name for valid identifiers
                 name = self.last_tokens
-                if name and (name[0].isalpha() or name[0] in ('_', '$')):
+                if name and (name[0].isalpha() or name[0] in ('_', '$', '#')):
                     self.function_name = name
                 self._in_prop_value = True
                 return
@@ -306,7 +345,7 @@ class TypeScriptStates(CodeStateMachine):
         elif token == '=':
             # Only set function_name for valid identifiers
             name = self.last_tokens
-            if name and (name[0].isalpha() or name[0] in ('_', '$')):
+            if name and (name[0].isalpha() or name[0] in ('_', '$', '#')):
                 self.function_name = name
         elif token == "(":
             # Check if this is a method call or constructor
@@ -347,6 +386,7 @@ class TypeScriptStates(CodeStateMachine):
             # Reset modifiers on newline/semicolon
             self._static_seen = False
             self._async_seen = False
+            self._in_abstract_context = False
             self._in_prop_value = False
 
         if token == '`':
@@ -401,6 +441,10 @@ class TypeScriptStates(CodeStateMachine):
             self.next(self._state_global, token)
 
     def _push_function_to_stack(self):
+        if self._in_abstract_context:
+            return
+        if self.function_name in _JS_BUILTIN_CALLABLES:
+            return
         self.started_function = True
         self.context.push_new_function(self.function_name or '(anonymous)')
 
@@ -430,7 +474,7 @@ class TypeScriptStates(CodeStateMachine):
             return
         if token != '(':
             # Only set function_name for valid identifiers
-            if token and (token[0].isalpha() or token[0] in ('_', '$')):
+            if token and (token[0].isalpha() or token[0] in ('_', '$', '#')):
                 self.function_name = token
             else:
                 self.function_name = ''
@@ -453,7 +497,17 @@ class TypeScriptStates(CodeStateMachine):
         if token == ')':
             self._state = self._expecting_func_opening_bracket
         elif token != '(':
-            self.context.parameter(token)
+            # Filter out TypeScript type keywords and operators from parameter count
+            if token == ',':
+                self.context.parameter(',')
+            elif token in _TS_TYPE_KEYWORDS:
+                pass
+            elif token in ('*', '+', '-', '/', '%', '=', '.'):
+                pass
+            elif (token.replace('_', '').replace('?', '').isalnum() and
+                  token.replace('?', '') and
+                  token.replace('?', '')[0].isalpha()):
+                self.context.parameter(token.replace('?', ''))
             return
         self.context.add_to_long_function_name(" " + token)
 
@@ -461,6 +515,12 @@ class TypeScriptStates(CodeStateMachine):
         # Do not reset started_function for arrow functions (=>)
         if token == ':':
             self._consume_type_annotation()
+        elif token == ';' and self.as_object and self._in_abstract_context:
+            # Abstract method declaration ends with ';' — no body
+            if self.started_function:
+                self._pop_function_from_stack()
+            self._in_abstract_context = False
+            self.next(self._state_global)
         elif token != '{' and token != '=>':
             if self.started_function:
                 # Arrow function not confirmed (no => or { after params).

--- a/lizard_languages/typescript.py
+++ b/lizard_languages/typescript.py
@@ -312,7 +312,13 @@ class TypeScriptStates(CodeStateMachine):
                     return
                 if not self.started_function:
                     self.arrow_function_pending = True
-                    self._function(self.last_tokens)
+                    # When last_tokens is '=' we're in a field assignment
+                    # pattern (field = () => {}), so use function_name which
+                    # was set by the '=' handler to the field name.
+                    if self.last_tokens == '=' and self.function_name:
+                        self._function(self.function_name)
+                    else:
+                        self._function(self.last_tokens)
                 self.next(self._function, token)
                 return
             # If we've seen async/static and this is an identifier, it's likely a method name

--- a/lizard_languages/typescript.py
+++ b/lizard_languages/typescript.py
@@ -128,12 +128,6 @@ _TS_TYPE_KEYWORDS = frozenset([
     'object', 'unknown', 'never',
 ])
 
-# Built-in constructors/functions that should not be detected as function definitions.
-# These appear as `String(x)`, `Number(x)` etc. — calls, not definitions.
-_JS_BUILTIN_CALLABLES = frozenset([
-    'String', 'Number', 'Boolean', 'Array', 'Object',
-])
-
 
 class TypeScriptStates(CodeStateMachine):
     def __init__(self, context):
@@ -449,8 +443,6 @@ class TypeScriptStates(CodeStateMachine):
     def _push_function_to_stack(self):
         if self._in_abstract_context:
             return
-        if self.function_name in _JS_BUILTIN_CALLABLES:
-            return
         self.started_function = True
         self.context.push_new_function(self.function_name or '(anonymous)')
 
@@ -491,6 +483,7 @@ class TypeScriptStates(CodeStateMachine):
             if not self.started_function:
                 self._push_function_to_stack()
             self.arrow_function_pending = False
+            self._generic_depth_in_dec = 0
             self._state = self._dec
             if token == '(':
                 self._dec(token)
@@ -505,15 +498,25 @@ class TypeScriptStates(CodeStateMachine):
         elif token != '(':
             # Filter out TypeScript type keywords and operators from parameter count
             if token == ',':
-                self.context.parameter(',')
+                # Ignore commas inside generic type brackets: Map<K, V>
+                if not getattr(self, '_generic_depth_in_dec', 0):
+                    self.context.parameter(',')
+            elif token == '<':
+                self._generic_depth_in_dec = getattr(
+                    self, '_generic_depth_in_dec', 0) + 1
+            elif token == '>':
+                depth = getattr(self, '_generic_depth_in_dec', 0)
+                if depth > 0:
+                    self._generic_depth_in_dec = depth - 1
             elif token in _TS_TYPE_KEYWORDS:
                 pass
             elif token in ('*', '+', '-', '/', '%', '=', '.'):
                 pass
-            elif (token.replace('_', '').replace('?', '').isalnum() and
-                  token.replace('?', '') and
-                  token.replace('?', '')[0].isalpha()):
-                self.context.parameter(token.replace('?', ''))
+            elif not getattr(self, '_generic_depth_in_dec', 0):
+                if (token.replace('_', '').replace('?', '').isalnum() and
+                        token.replace('?', '') and
+                        token.replace('?', '')[0].isalpha()):
+                    self.context.parameter(token.replace('?', ''))
             return
         self.context.add_to_long_function_name(" " + token)
 

--- a/test/test_languages/testES6.py
+++ b/test/test_languages/testES6.py
@@ -273,7 +273,6 @@ class Test_ES6_optional_chaining_no_fp(unittest.TestCase):
 class Test_ES6_private_class_fields(unittest.TestCase):
     """Tests private class field methods."""
 
-    @unittest.skip("Requires #private field tokenizer enhancement")
     def test_private_field_methods(self):
         code = '''
         class Counter {

--- a/test/test_languages/testES6.py
+++ b/test/test_languages/testES6.py
@@ -215,7 +215,7 @@ class Test_ES6_class_field_arrows(unittest.TestCase):
     """Tests class field arrow functions."""
 
     def test_class_arrow_fields(self):
-        """Arrow functions as class fields should be detected"""
+        """Arrow functions as class fields should use the field name"""
         code = '''
         class Btn {
             handleClick = () => { this.setState({clicked: true}); };
@@ -224,11 +224,9 @@ class Test_ES6_class_field_arrows(unittest.TestCase):
         }
         '''
         functions = get_js_function_list(code)
-        names = [f.name for f in functions]
-        # Arrow field functions are anonymous, method is named
-        self.assertIn("render", names)
-        anon_count = sum(1 for n in names if n == "(anonymous)")
-        self.assertGreaterEqual(anon_count, 2)
+        self.assertEqual(
+            ["handleClick", "handleHover", "render"],
+            [f.name for f in functions])
 
     def test_class_field_then_method(self):
         """Regular class method after arrow field should be detected"""
@@ -240,9 +238,37 @@ class Test_ES6_class_field_arrows(unittest.TestCase):
         }
         '''
         functions = get_js_function_list(code)
-        names = [f.name for f in functions]
-        self.assertIn("reset", names)
-        self.assertIn("getCount", names)
+        self.assertEqual(
+            ["tick", "reset", "getCount"],
+            [f.name for f in functions])
+
+    def test_field_arrow_with_params(self):
+        """Field arrow with parameters should use the field name"""
+        code = '''
+        class EventBus {
+            emit = (event, data) => { this.listeners[event](data); };
+            on = (event, cb) => { this.listeners[event] = cb; };
+        }
+        '''
+        functions = get_js_function_list(code)
+        self.assertEqual(
+            ["emit", "on"],
+            [f.name for f in functions])
+
+    def test_field_arrow_block_body(self):
+        """Field arrow with block body and complexity"""
+        code = '''
+        class Validator {
+            validate = (value) => {
+                if (!value) return false;
+                if (value.length < 3) return false;
+                return true;
+            };
+        }
+        '''
+        functions = get_js_function_list(code)
+        self.assertEqual(["validate"], [f.name for f in functions])
+        self.assertGreater(functions[0].cyclomatic_complexity, 1)
 
 
 class Test_ES6_optional_chaining_no_fp(unittest.TestCase):

--- a/test/test_languages/testTypeScript.py
+++ b/test/test_languages/testTypeScript.py
@@ -647,7 +647,6 @@ class Test_TypeScript_generic_arrow_functions(unittest.TestCase):
 class Test_TypeScript_interface_enum_no_fp(unittest.TestCase):
     """Tests that interfaces and enums do NOT produce false positives."""
 
-    @unittest.skip("Requires interface skipping enhancement")
     def test_interface_with_methods(self):
         """Interface method signatures should not be detected as functions"""
         code = '''
@@ -676,7 +675,6 @@ class Test_TypeScript_interface_enum_no_fp(unittest.TestCase):
         functions = get_ts_function_list(code)
         self.assertEqual(["createConfig"], [f.name for f in functions])
 
-    @unittest.skip("Requires interface skipping enhancement")
     def test_index_signature_no_fp(self):
         """Index signatures with arrow types should not be FPs"""
         code = '''

--- a/test/test_languages/testTypeScript.py
+++ b/test/test_languages/testTypeScript.py
@@ -998,3 +998,126 @@ class Test_ts_class_field_arrow_naming(unittest.TestCase):
         self.assertIn("process", names)
         anon_count = sum(1 for n in names if n == "(anonymous)")
         self.assertGreaterEqual(anon_count, 2)
+
+
+class Test_ts_builtin_name_functions(unittest.TestCase):
+    """Functions/methods named after JS builtins must still be detected."""
+
+    def test_function_named_String(self):
+        """function String() {} is a legitimate function definition"""
+        code = 'function String() { return "custom"; }'
+        functions = get_ts_function_list(code)
+        self.assertEqual(["String"], [f.name for f in functions])
+
+    def test_class_method_named_Number(self):
+        """Class method named Number should be detected"""
+        code = '''
+        class Util {
+            Number() { return 0; }
+            Boolean() { return true; }
+        }
+        '''
+        functions = get_ts_function_list(code)
+        self.assertEqual(["Number", "Boolean"], [f.name for f in functions])
+
+    def test_object_method_named_Array(self):
+        """Object method named Array should be detected"""
+        code = '''
+        const obj = {
+            Array() { return []; },
+            Object() { return {}; }
+        };
+        '''
+        functions = get_ts_function_list(code)
+        names = [f.name for f in functions]
+        self.assertIn("Array", names)
+        self.assertIn("Object", names)
+
+    def test_builtin_call_not_detected(self):
+        """const s = String(42) should NOT be a function definition"""
+        code = '''
+        const s = String(42);
+        const n = Number("5");
+        function realFn() { return 1; }
+        '''
+        functions = get_ts_function_list(code)
+        self.assertEqual(["realFn"], [f.name for f in functions])
+
+    def test_bare_builtin_call_not_detected(self):
+        """String(42) bare call should NOT be a function definition"""
+        code = '''
+        String(42);
+        Number(true);
+        function realFn() { return 1; }
+        '''
+        functions = get_ts_function_list(code)
+        self.assertEqual(["realFn"], [f.name for f in functions])
+
+
+class Test_ts_abstract_method_detection(unittest.TestCase):
+    """Abstract methods should not be detected as functions."""
+
+    def test_abstract_method_skipped(self):
+        """abstract doWork(): void should not be detected"""
+        code = '''
+        abstract class Base {
+            abstract doWork(): void;
+            concrete() { return 1; }
+        }
+        '''
+        functions = get_ts_function_list(code)
+        self.assertEqual(["concrete"], [f.name for f in functions])
+
+    def test_abstract_with_params_skipped(self):
+        """abstract method with params should not be detected"""
+        code = '''
+        abstract class Service {
+            abstract fetch(url: string, options: object): Promise<Response>;
+            abstract parse(data: string): object;
+            process() { return this.fetch("").then(r => this.parse(r)); }
+        }
+        '''
+        functions = get_ts_function_list(code)
+        names = [f.name for f in functions]
+        self.assertIn("process", names)
+        self.assertNotIn("fetch", names)
+        self.assertNotIn("parse", names)
+
+    def test_abstract_class_not_abstract_function(self):
+        """abstract class declaration should not affect non-abstract methods"""
+        code = '''
+        abstract class Widget {
+            render() { return null; }
+            update() { this.render(); }
+        }
+        '''
+        functions = get_ts_function_list(code)
+        self.assertEqual(["render", "update"], [f.name for f in functions])
+
+
+class Test_ts_param_type_filtering(unittest.TestCase):
+    """Type keywords should be filtered from parameter counts."""
+
+    def test_simple_typed_params(self):
+        """fn(x: string, y: number) should have 2 params"""
+        code = 'function fn(x: string, y: number, z: boolean) {}'
+        functions = get_ts_function_list(code)
+        self.assertEqual(3, functions[0].parameter_count)
+
+    def test_generic_type_in_params(self):
+        """fn(x: Map<string, number>, y: boolean) — generic comma not counted"""
+        code = 'function fn(x: Map<string, number>, y: boolean) {}'
+        functions = get_ts_function_list(code)
+        self.assertEqual(2, functions[0].parameter_count)
+
+    def test_nested_generic_in_params(self):
+        """fn(x: Promise<Array<string>>, y: number) — nested generics"""
+        code = 'function fn(x: Promise<Array<string>>, y: number) {}'
+        functions = get_ts_function_list(code)
+        self.assertEqual(2, functions[0].parameter_count)
+
+    def test_multiple_generic_params(self):
+        """fn(a: Map<K, V>, b: Set<T>, c: number) — multiple generics"""
+        code = 'function fn(a: Map<K, V>, b: Set<T>, c: number) {}'
+        functions = get_ts_function_list(code)
+        self.assertEqual(3, functions[0].parameter_count)

--- a/test/test_languages/testTypeScript.py
+++ b/test/test_languages/testTypeScript.py
@@ -887,7 +887,7 @@ class Test_TypeScript_misc_patterns(unittest.TestCase):
         self.assertEqual(["safeFetch"], [f.name for f in functions])
 
     def test_class_arrow_field(self):
-        """Class arrow field should detect the arrow as anonymous"""
+        """Class arrow field should use the field name, not (anonymous)"""
         code = '''
         class Btn {
             handleClick = () => { console.log("click"); };
@@ -896,5 +896,105 @@ class Test_TypeScript_misc_patterns(unittest.TestCase):
         '''
         functions = get_ts_function_list(code)
         names = [f.name for f in functions]
-        self.assertIn("(anonymous)", names)
+        self.assertIn("handleClick", names)
         self.assertIn("render", names)
+
+
+class Test_ts_class_field_arrow_naming(unittest.TestCase):
+    """Class field arrows (field = () => {}) should be named by the field."""
+
+    def test_basic_class_field_arrow(self):
+        """handleClick = () => {} should be named handleClick"""
+        code = '''
+        class Btn {
+            handleClick = () => { console.log("click"); };
+        }
+        '''
+        functions = get_ts_function_list(code)
+        self.assertEqual(["handleClick"], [f.name for f in functions])
+
+    def test_multiple_class_field_arrows(self):
+        """Multiple field arrows should each get their field name"""
+        code = '''
+        class Form {
+            handleSubmit = () => { this.submit(); };
+            handleReset = () => { this.reset(); };
+            validate = (value: string) => { return value.length > 0; };
+        }
+        '''
+        functions = get_ts_function_list(code)
+        self.assertEqual(
+            ["handleSubmit", "handleReset", "validate"],
+            [f.name for f in functions])
+
+    def test_field_arrows_mixed_with_methods(self):
+        """Field arrows and regular methods should all be correctly named"""
+        code = '''
+        class UserDashboard {
+            handleLogin = () => { this.login(); };
+            handleLogout = () => { this.logout(); };
+            render() { return null; }
+            componentDidMount() { this.fetchData(); }
+        }
+        '''
+        functions = get_ts_function_list(code)
+        self.assertEqual(
+            ["handleLogin", "handleLogout", "render", "componentDidMount"],
+            [f.name for f in functions])
+
+    def test_typed_field_arrow(self):
+        """Field arrow with type annotation should use field name"""
+        code = '''
+        class Api {
+            fetchData = async (url: string): Promise<Response> => {
+                return fetch(url);
+            };
+        }
+        '''
+        functions = get_ts_function_list(code)
+        self.assertEqual(["fetchData"], [f.name for f in functions])
+
+    def test_field_arrow_after_typed_property(self):
+        """Field arrow after a typed property (not arrow) should be named"""
+        code = '''
+        class Counter {
+            count: number;
+            increment = () => { this.count++; };
+            decrement = () => { this.count--; };
+            getCount() { return this.count; }
+        }
+        '''
+        functions = get_ts_function_list(code)
+        self.assertEqual(
+            ["increment", "decrement", "getCount"],
+            [f.name for f in functions])
+
+    def test_static_field_arrow(self):
+        """Static field arrows should be detected (name may vary)"""
+        code = '''
+        class Logger {
+            static instance = () => { return new Logger(); };
+            log() { console.log("msg"); }
+        }
+        '''
+        functions = get_ts_function_list(code)
+        names = [f.name for f in functions]
+        self.assertIn("log", names)
+        self.assertEqual(2, len(functions))
+
+    def test_inline_callbacks_remain_anonymous(self):
+        """Inline callbacks (.map, .filter) should stay (anonymous)"""
+        code = '''
+        class Processor {
+            process(items: string[]) {
+                return items
+                    .map(x => x.trim())
+                    .filter(x => x.length > 0);
+            }
+        }
+        '''
+        functions = get_ts_function_list(code)
+        names = [f.name for f in functions]
+        self.assertIn("process", names)
+        anon_count = sum(1 for n in names if n == "(anonymous)")
+        self.assertGreaterEqual(anon_count, 2)


### PR DESCRIPTION
## Intent

Add 5 enhancements to the TypeScript/JavaScript parser that improve detection accuracy and report clarity for common TS/JS patterns. These are **additive features**, not bug fixes — the parser works without them, but produces less precise output.

**Depends on:** PR #4 (bug fixes) — this branch builds on top of the bug-fix commit.

## Enhancements

### 1. Interface skipping

**Problem:** `interface Service { get(id: string): Promise<Item>; }` produces false-positive function detections — interface method *signatures* are not runtime functions.

**Fix:** Skip entire `interface Foo { ... }` blocks.

| | Without | With |
|--|---------|------|
| `interface Service { get(): Item; create(): Item; } function realFn() {}` | `[get, create, realFn]` (2 FPs) | `[realFn]` |

### 2. Abstract method handling

**Problem:** `abstract doWork(): void;` has no body but is detected as a function.

**Fix:** Track `_in_abstract_context` flag; skip function push when abstract.

| | Without | With |
|--|---------|------|
| `abstract class Base { abstract doWork(): void; concrete() {} }` | `[doWork, concrete]` | `[concrete]` |

### 3. Private `#method` syntax (ES2022)

**Problem:** `#count = 0` confuses the tokenizer, killing subsequent method detection.

**Fix:** Add `#\w+` to tokenizer regex and `#` to identifier validation.

| | Without | With |
|--|---------|------|
| `class C { #count = 0; increment() {} getCount() {} }` | `[]` | `[increment, getCount]` |

### 4. Parameter type filtering with generic support

**Problem:** TypeScript type keywords (`string`, `number`, `boolean`, etc.) pollute `full_parameters` entries. For example, `fn(x: string, y: number)` produces `full_parameters=['x : string', ' y : number']` instead of clean `['x', 'y']`.

Additionally, generic types with commas like `Map<string, number>` cause the comma inside `<...>` to be treated as a parameter separator, producing wrong parameter counts.

**Fix:** Filter `_TS_TYPE_KEYWORDS` from `_dec` and add `<...>` depth tracking to skip commas inside generic type brackets.

| | Without | With |
|--|---------|------|
| `function fn(x: string, y: number, z: boolean) {}` | full_params: `['x : string', ' y : number', ' z : boolean']` | full_params: `['x', 'y', 'z']` |
| `function fn(x: Map<string, number>, y: boolean) {}` | 3 params (generic comma counted) | 2 params (correct) |

### 5. Class field arrow naming

**Problem:** Class field arrows like `handleClick = () => { ... }` are reported as `(anonymous)` even though the field name is available. This makes complexity reports harder to act on — when a threshold is exceeded, the developer has to hunt through the file to find which anonymous function is the culprit.

**Root cause:** The class body `(` handler passed `self.last_tokens` to `_function()`, but after `=`, `last_tokens` has become `'='`, not the field name. The non-class code path (`const handler = () => {}`) already worked correctly because it used `self.function_name`.

**Fix:** When `last_tokens == '='` and `function_name` is set (field assignment pattern), pass `function_name` (the field name) instead of `last_tokens`.

| | Without | With |
|--|---------|------|
| `class Btn { handleClick = () => { ... }; render() {} }` | `[(anonymous), render]` | `[handleClick, render]` |
| `class Form { validate = (v) => { if (!v) return false; }; submit() {} }` | `[(anonymous), submit]` | `[validate, submit]` |

**Why this matters:** Class field arrows are extremely common in modern TS/JS (React class components, event handlers, API clients). Naming them correctly makes complexity reports immediately actionable — `handleClick exceeds CCN 15` is clear; `(anonymous) exceeds CCN 15` requires manual searching.

**What stays anonymous:** Inline callbacks (`.map(x => x * 2)`, `setTimeout(function() {})`) remain `(anonymous)` as expected — they have no assigned name.

**Note on built-in callable filtering:** An earlier version of this PR included a `_JS_BUILTIN_CALLABLES` filter to suppress `const s = String(42)` from being detected as a function definition. This was removed because it was over-broad (suppressed ALL functions named `String`, `Number`, etc., including legitimate definitions and class methods) and because the existing call-vs-definition logic already handles these cases correctly without a separate filter.

## Evidence

```
# All enhancements verified:
interface:        [('realFn', 1, 0)]                       # interface methods skipped
abstract:         [('concrete', 1, 0)]                     # abstract method skipped
private-field:    [('increment', 1, 0), ('getCount', 1, 0)]  # #field handled
param-filter:     fn(x: Map<string, number>, y: boolean) -> 2 params (correct)
field-arrow-name: [('handleClick', 1, 0), ('render', 1, 0)]  # field name, not (anonymous)
builtin-call:     const s = String(42) -> not detected (call-vs-definition handles it)
builtin-def:      function String() {} -> detected correctly (no false negative)
```

## Test suite

```
$ python3 -m unittest test.test_languages.testTypeScript \
    test.test_languages.testES6 test.test_languages.testJavaScript \
    test.test_languages.testJSX test.test_languages.testTSX -v
240 tests, 0 failures, 5 skipped
```

**Zero failures, zero regressions.** Includes 24 new/updated tests across the enhancements:
- 7 tests for class field arrow naming (testTypeScript)
- 4 tests for JS class field arrow naming (testES6)
- 5 tests for builtin-named function detection (testTypeScript)
- 3 tests for abstract method handling (testTypeScript)
- 4 tests for parameter type filtering with generics (testTypeScript)
- 1 updated test for class arrow field (testTypeScript)

## Changes

- `typescript.py`: interface skip block, `_in_abstract_context` flag, `#\w+` tokenizer regex, `_TS_TYPE_KEYWORDS` constant, `_dec` parameter filtering with `<...>` generic depth tracking, field arrow name preservation, removed over-broad `_JS_BUILTIN_CALLABLES` filter
- `tsx.py`: `#\w+` added to tokenizer regex
- `testTypeScript.py`: +227 lines across 4 new test classes
- `testES6.py`: +32 lines, 4 updated/new tests
